### PR TITLE
Tweak profile for improved readability

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,11 +1,11 @@
 ## Meet Swift
 Swift is a general-purpose programming language that’s approachable for newcomers and powerful for experts. It’s used to develop everything from apps and system software to cloud services and embedded firmware, and runs on a variety of platforms including macOS, Linux, and Windows.
 
-* Visit [Swift.org](https://www.swift.org) to [download Swift](https://www.swift.org/install), [read the blog](https://www.swift.org/blog), and [tour the language](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/guidedtour/)
-* Check out key repositories like the [compiler](https://github.com/apple/swift/) and [package manager](https://github.com/apple/swift-package-manager)
-* Learn more about contributing [bug reports](https://www.swift.org/contributing/#reporting-bugs), [language and API proposals](https://www.swift.org/contributing/#swift-evolution), [code changes](https://www.swift.org/contributing/#contributing-code), or [community organization](https://www.swift.org/community/)
+* **Visit [Swift.org](https://www.swift.org)**: [Download Swift](https://www.swift.org/install), [read the blog](https://www.swift.org/blog), and [tour the language](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/guidedtour/)
+* **Key Repositories**: Check out important repositories like the [compiler](https://github.com/apple/swift/) and [package manager](https://github.com/apple/swift-package-manager)
+* **Get Involved**: Learn how you can contribute through [bug reports](https://www.swift.org/contributing/#reporting-bugs), [language and API proposals](https://www.swift.org/contributing/#swift-evolution), [code changes](https://www.swift.org/contributing/#contributing-code), and [community organization](https://www.swift.org/community/)
 
 🚧 **Pardon Our Dust** 🚧
 
-While it may seem a bit empty at the moment, we are in the process of transferring repositories from their current locations. This staged migration helps minimize potential disruptions. For more information, check out our [forum post](https://forums.swift.org/t/new-github-organization-for-the-swift-project/72336).
+While it may seem a bit empty at the moment, we're in the process of transferring repositories from their current locations. This staged migration aims to minimize disruptions. For more information, check out our [forum post](https://forums.swift.org/t/new-github-organization-for-the-swift-project/72336).
 


### PR DESCRIPTION
Alternative profile for SwiftLang, which at least for me, improves readability. 

The three items in the enumerated list start with verbs in bold, encouraging engagement and also makes it a bit more glanceable, at least for me. Might be completely subjective :) 

Changed from `"we are"` to `"we're"` to be more consistent with other phrasing like `"that’s"` and `"It's"`.

After:
<img width="1297" alt="Screenshot 2024-06-11 at 00 12 30" src="https://github.com/swiftlang/.github/assets/864410/b8978a93-431e-433c-a2b7-9da0bbffc9b3">
