### PR TITLE
Add release branch pull request template

### DIFF
--- a/PULL_REQUEST_TEMPLATE/release.md
+++ b/PULL_REQUEST_TEMPLATE/release.md
@@ -1,0 +1,33 @@
+  - **Explanation**:
+    <!--
+    A description of the changes. This can be brief, but it should be clear.
+    -->
+  - **Scope**:
+    <!--
+    An assessment of the impact and importance of the changes. For example, can
+    the changes break existing code?
+    -->
+  - **Issues**:
+    <!--
+    References to issues the changes resolve, if any.
+    -->
+  - **Original PRs**:
+    <!--
+    Links to mainline branch pull requests in which the changes originated.
+    -->
+  - **Risk**:
+    <!--
+    The (specific) risk to the release for taking the changes.
+    -->
+  - **Testing**:
+    <!--
+    The specific testing that has been done or needs to be done to further
+    validate any impact of the changes.
+    -->
+  - **Reviewers**:
+    <!--
+    The code owners that GitHub-approved the original changes in the mainline
+    branch pull requests. If an original change has not been GitHub-approved by
+    a respective code owner, provide a reason. Technical review can be delegated
+    by a code owner or otherwise requested as deemed appropriate or useful.
+    -->


### PR DESCRIPTION
I am not certain that this will work because [GitHub](https://github.blog/changelog/2019-02-21-organization-wide-community-health-files/) is not being crystal clear about pull request templates in particular, but there is no other way to test it. If it does, the template will serve a dual purpose: 
* It will enable us to create pull requests with it in any repository under this org, by using a query parameter: `template=release.md`
* It will enable people to propose changes to the form through pull requests, and will be the only source of truth regarding the form.